### PR TITLE
chore: repo safety baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @potato16-shin

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,13 @@
+---
+name: Bug report
+about: Report a reproducible problem
+---
+
+## Summary
+
+## Steps to reproduce
+1. 
+
+## Expected behavior
+
+## Environment

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## What changed
+- 
+
+## Why
+- 
+
+## Checklist
+- [ ] CI passed
+- [ ] No secrets included
+- [ ] Docs updated (if needed)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 
 # mkdocs build output
 site/
+.env
+*.pem
+*.key


### PR DESCRIPTION
자동 안전장치 점검 결과에 따라 기본 보안/협업 파일을 추가합니다.

- Dependabot 설정
- CODEOWNERS
- PR/Issue 템플릿
- .gitignore에 민감 파일 패턴 추가
